### PR TITLE
feat: Add buy lottery endpoint and list lotteries of user endpoint

### DIFF
--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/configs/SecurityConfig.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/configs/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -19,8 +18,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain appSecurity(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
                 .httpBasic(Customizer.withDefaults())
                 .authorizeHttpRequests((authorize) -> {
+            authorize.requestMatchers("/lotteries/**").permitAll();
+            authorize.requestMatchers("/users/**").permitAll();
             authorize.requestMatchers("/admin/**").hasRole("ADMIN");
             authorize.anyRequest().authenticated();
         });

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/controllers/UserController.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/controllers/UserController.java
@@ -1,0 +1,48 @@
+package com.kbtg.bootcamp.posttest.controllers;
+
+import com.kbtg.bootcamp.posttest.dto.BuyLotteryResponse;
+import com.kbtg.bootcamp.posttest.dto.GetLotteriesByUserIdResponse;
+import com.kbtg.bootcamp.posttest.entities.UserTicket;
+import com.kbtg.bootcamp.posttest.exceptions.LotteryNotFoundException;
+import com.kbtg.bootcamp.posttest.exceptions.LotterySoldOutException;
+import com.kbtg.bootcamp.posttest.services.LotteryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final LotteryService lotteryService;
+
+    public UserController(LotteryService lotteryService) {
+        this.lotteryService = lotteryService;
+    }
+
+    @PostMapping("/{userId}/lotteries/{ticketId}")
+    public ResponseEntity<BuyLotteryResponse> buyLottery(
+            @PathVariable(value = "userId") String userId,
+            @PathVariable(value = "ticketId") String ticketId
+    ) {
+        UserTicket userTicket = this.lotteryService.buyLottery(userId, ticketId);
+
+        BuyLotteryResponse response = new BuyLotteryResponse(userTicket.getId().toString());
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{userId}/lotteries")
+    public ResponseEntity<GetLotteriesByUserIdResponse> getLotteriesByUserId(@PathVariable(value = "userId") String userId) {
+        List<String> tickets = List.of("123456", "654321");
+        GetLotteriesByUserIdResponse response = new GetLotteriesByUserIdResponse(tickets, 2, 160);
+        return ResponseEntity.ok().body(response);
+    }
+
+
+    @ExceptionHandler(value = {LotteryNotFoundException.class, LotterySoldOutException.class})
+    public ResponseEntity<String> handleException(Exception e) {
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/dto/BuyLotteryResponse.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/dto/BuyLotteryResponse.java
@@ -1,0 +1,6 @@
+package com.kbtg.bootcamp.posttest.dto;
+
+public record BuyLotteryResponse(
+        String id
+) {
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/dto/GetLotteriesByUserIdResponse.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/dto/GetLotteriesByUserIdResponse.java
@@ -1,0 +1,10 @@
+package com.kbtg.bootcamp.posttest.dto;
+
+import java.util.List;
+
+public record GetLotteriesByUserIdResponse(
+        List<String> tickets,
+        Integer count,
+        Integer cost
+) {
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/entities/UserTicket.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/entities/UserTicket.java
@@ -6,24 +6,25 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
-
 @Entity
-@Table(name = "lottery")
+@Table(name = "user_ticket")
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Lottery {
+public class UserTicket {
 
     @Id
-    @Column(name = "ticket")
-    private String ticket;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private Integer id;
 
-    @Column(name = "price")
-    private Integer price;
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "ticket_id")
+    private String ticketId;
 
     @Column(name = "amount")
     private Integer amount;
-
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/exceptions/LotteryNotFoundException.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/exceptions/LotteryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.kbtg.bootcamp.posttest.exceptions;
+
+
+public class LotteryNotFoundException extends RuntimeException {
+
+    public LotteryNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/exceptions/LotterySoldOutException.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/exceptions/LotterySoldOutException.java
@@ -1,0 +1,8 @@
+package com.kbtg.bootcamp.posttest.exceptions;
+
+public class LotterySoldOutException extends RuntimeException{
+
+    public LotterySoldOutException(String message) {
+        super(message);
+    }
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/repositories/LotteryRepository.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/repositories/LotteryRepository.java
@@ -2,6 +2,16 @@ package com.kbtg.bootcamp.posttest.repositories;
 
 import com.kbtg.bootcamp.posttest.entities.Lottery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LotteryRepository extends JpaRepository<Lottery, String> {
+    @Query(value = """
+            UPDATE lottery
+            SET amount = amount + :amount
+            WHERE ticket = :ticketId
+            RETURNING *
+            """, nativeQuery = true)
+    Lottery updateTicketAmountInStore(String ticketId, int amount);
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/repositories/UserTicketRepository.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/repositories/UserTicketRepository.java
@@ -1,0 +1,29 @@
+package com.kbtg.bootcamp.posttest.repositories;
+
+import com.kbtg.bootcamp.posttest.entities.UserTicket;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserTicketRepository extends JpaRepository<UserTicket, Integer> {
+
+    @Query(value = """
+               UPDATE user_ticket
+               SET amount = amount + :amount
+               WHERE user_id = :userId
+               AND ticket_id = :ticketId
+               RETURNING *
+               """, nativeQuery = true)
+    UserTicket updateTicketAmountOfUser(
+            @Param("userId") String userId,
+            @Param("ticketId") String ticketId,
+            @Param("amount") int amount
+    );
+
+    boolean existsByUserIdAndTicketId(String userId, String ticketId);
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/services/LotteryService.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/services/LotteryService.java
@@ -2,10 +2,12 @@ package com.kbtg.bootcamp.posttest.services;
 
 import com.kbtg.bootcamp.posttest.dto.CreateLotteryRequest;
 import com.kbtg.bootcamp.posttest.entities.Lottery;
+import com.kbtg.bootcamp.posttest.entities.UserTicket;
 
 import java.util.List;
 
 public interface LotteryService {
     Lottery createLottery(CreateLotteryRequest lottery);
     List<Lottery> getLotteries();
+    UserTicket buyLottery(String userId, String ticketId);
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/services/LotteryServiceImpl.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/services/LotteryServiceImpl.java
@@ -2,20 +2,29 @@ package com.kbtg.bootcamp.posttest.services;
 
 import com.kbtg.bootcamp.posttest.dto.CreateLotteryRequest;
 import com.kbtg.bootcamp.posttest.entities.Lottery;
+import com.kbtg.bootcamp.posttest.entities.UserTicket;
+import com.kbtg.bootcamp.posttest.exceptions.LotteryNotFoundException;
+import com.kbtg.bootcamp.posttest.exceptions.LotterySoldOutException;
 import com.kbtg.bootcamp.posttest.repositories.LotteryRepository;
+import com.kbtg.bootcamp.posttest.repositories.UserTicketRepository;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Service
 public class LotteryServiceImpl implements LotteryService {
 
     private final LotteryRepository lotteryRepository;
+    private final UserTicketRepository userTicketRepository;
 
-    public LotteryServiceImpl(LotteryRepository lotteryRepository) {
+    public LotteryServiceImpl(LotteryRepository lotteryRepository, UserTicketRepository userTicketRepository) {
         this.lotteryRepository = lotteryRepository;
+        this.userTicketRepository = userTicketRepository;
     }
 
     @Override
@@ -35,5 +44,36 @@ public class LotteryServiceImpl implements LotteryService {
     @Override
     public List<Lottery> getLotteries() {
         return this.lotteryRepository.findAll();
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public UserTicket buyLottery(String userId, String ticketId) {
+        Optional<Lottery> optionalLottery = this.lotteryRepository.findById(ticketId);
+        if (optionalLottery.isEmpty()) {
+            throw new LotteryNotFoundException("Lottery with id " + ticketId + " not found");
+        }
+
+        Lottery lottery = optionalLottery.get();
+        if (lottery.getAmount() <= 0) {
+            throw new LotterySoldOutException("Lottery with id " + ticketId + " is sold out");
+        }
+
+        this.lotteryRepository.updateTicketAmountInStore(ticketId, -1);
+
+        UserTicket userTicket;
+        if (this.userTicketRepository.existsByUserIdAndTicketId(userId, ticketId)) {
+            userTicket = this.userTicketRepository.updateTicketAmountOfUser(userId, ticketId, 1);
+        } else {
+            userTicket = UserTicket
+                    .builder()
+                    .ticketId(ticketId)
+                    .userId(userId)
+                    .amount(1)
+                    .build();
+            this.userTicketRepository.save(userTicket);
+        }
+
+        return userTicket;
     }
 }

--- a/posttest/src/main/resources/application.properties
+++ b/posttest/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.username=lotteryusr
 spring.datasource.password=secret
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.sql.init.mode=always
+spring.sql.init.platform=postgresql
+spring.jpa.defer-datasource-initialization=true

--- a/posttest/src/main/resources/data-postgresql.sql
+++ b/posttest/src/main/resources/data-postgresql.sql
@@ -1,0 +1,8 @@
+INSERT INTO lottery (ticket, price ,amount)
+VALUES
+    ('123456', 80, 3),
+    ('654321', 100, 0);
+
+INSERT INTO user_ticket (id, user_id, ticket_id, amount)
+VALUES
+    (1, 'username', '123456', 1);

--- a/posttest/src/test/java/com/kbtg/bootcamp/posttest/AdminLotteryStoreTests.java
+++ b/posttest/src/test/java/com/kbtg/bootcamp/posttest/AdminLotteryStoreTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -25,25 +26,84 @@ public class AdminLotteryStoreTests {
 
     @Test
     @DirtiesContext
-    @DisplayName("When admin creates lottery, then it is stored")
-    void whenAdminCreatesLotteryThenItIsStored() throws Exception {
+    @DisplayName("Given create lottery request when create lottery then the lottery is stored")
+    void givenCreateLotteryRequest_whenCreateLottery_thenTheLotteryIsStored() throws Exception {
         this.mvc.perform(
                 post("/admin/lotteries")
                         .with(csrf())
                         .contentType("application/json")
                         .content("""
                                 {
-                                	"ticket": "123456",
+                                	"ticket": "222333",
                                 	"price": 80,
                                 	"amount": 1
                                 }
                                 """)
                 )
+                .andDo(print())
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.ticket").value("123456"));
+                .andExpect(jsonPath("$.ticket").value("222333"));
 
         this.mvc.perform(get("/lotteries"))
+                .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.tickets").value(containsInAnyOrder("123456")));
+                .andExpect(jsonPath("$.tickets").value(anyOf(hasItem("222333"))));
+    }
+
+    @Test
+    @DisplayName("Given lottery when get lotteries then return lotteries")
+    void givenLottery_whenGetLotteries_thenReturnLotteries() throws Exception {
+        this.mvc.perform(get("/lotteries"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tickets", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("Given user id and ticket id when user buy lottery then the lottery is bought")
+    void givenUserIdAndTicketId_whenUserBuyLottery_thenTheLotteryIsBought() throws Exception {
+        this.mvc.perform(
+                post("/users/username/lotteries/123456")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists());
+
+        // query database to check if the lottery is bought
+    }
+
+    @Test
+    @DisplayName("Given user id and ticket id when lottery not found then response status is not found")
+    void givenUserIdAndTicketId_whenLotteryNotFound_thenResponseStatusIsNotFound() throws Exception {
+        this.mvc.perform(
+                post("/users/username/lotteries/43212")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Given user id and ticket id when lottery is found but sold out then response status is bad request")
+    void givenUserIdAndTicketId_whenLotteryIsFoundButSoldOut_thenResponseStatusIsBadRequest() throws Exception {
+        this.mvc.perform(
+                post("/users/username/lotteries/654321")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("When user list their lotteries then response with all lotteries they have with status ok")
+    void whenUserListTheirLotteries_thenResponseWithAllLotteriesTheyHaveWithStatusOk() throws Exception {
+        this.mvc.perform(get("/users/username/lotteries"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tickets").isArray())
+                .andExpect(jsonPath("$.count").isNumber())
+                .andExpect(jsonPath("$.cost").isNumber())
+                .andExpect(jsonPath("$.tickets.length()").value(2));
     }
 }

--- a/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/AdminControllerTest.java
+++ b/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/AdminControllerTest.java
@@ -1,0 +1,97 @@
+package com.kbtg.bootcamp.posttest.controllers;
+
+import com.kbtg.bootcamp.posttest.configs.SecurityConfig;
+import com.kbtg.bootcamp.posttest.entities.Lottery;
+import com.kbtg.bootcamp.posttest.services.LotteryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LotteryService lotteryService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("Given user is anonymous when create lottery then response with status unauthorized")
+    void givenUserIsAnonymous_whenCreateLottery_thenResponseWithStatusUnauthorized() throws Exception {
+        this.mvc.perform(
+                post("/admin/lotteries")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "notadmin", roles = "USER")
+    void givenUserIsNotAdmin_whenCreateLottery_thenResponseWithStatusForbidden() throws Exception {
+        this.mvc.perform(
+                post("/admin/lotteries")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "username", roles = "ADMIN")
+    void givenUserIsAdmin_whenCreateLottery_thenResponseCorrectlyWithStatusCreated() throws Exception {
+        when(this.lotteryService.createLottery(any())).thenReturn(
+                Lottery
+                        .builder()
+                        .ticket("123456")
+                        .price(80)
+                        .amount(2)
+                        .build()
+        );
+
+        this.mvc.perform(
+                post("/admin/lotteries")
+                        .with(csrf())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                    "ticket": "123456",
+                                    "price": 80,
+                                    "amount": 1
+                                }
+                                """)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.ticket").value("123456"));
+    }
+}

--- a/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/LotteryControllerTest.java
+++ b/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/LotteryControllerTest.java
@@ -1,0 +1,83 @@
+package com.kbtg.bootcamp.posttest.controllers;
+
+import com.kbtg.bootcamp.posttest.configs.SecurityConfig;
+import com.kbtg.bootcamp.posttest.entities.Lottery;
+import com.kbtg.bootcamp.posttest.services.LotteryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(LotteryController.class)
+class LotteryControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LotteryService lotteryService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("When lotteries service returns non-empty list then response list of tickets with status ok")
+    void givenUserIsAnonymous_whenLotteryServiceReturnNonEmptyList_thenResponseLotteriesCorrectlyWithStatusOk() throws Exception {
+        when(this.lotteryService.getLotteries()).thenReturn(List.of(
+                Lottery
+                        .builder()
+                        .ticket("123456")
+                        .price(80)
+                        .amount(1)
+                        .build(),
+                Lottery
+                        .builder()
+                        .ticket("453143")
+                        .price(100)
+                        .amount(2)
+                        .build()
+        ));
+
+        this.mvc.perform(get("/lotteries"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tickets.length()").value(2))
+                .andExpect(jsonPath("$.tickets").value(containsInAnyOrder("123456", "453143")));
+    }
+
+    @Test
+    @DisplayName("When lotteries service returns empty list then return empty list")
+    void whenLotteryServiceReturnsEmptyList_thenResponseWithEmptyListWithStatusOk() throws Exception {
+        when(this.lotteryService.getLotteries()).thenReturn(List.of());
+
+        this.mvc.perform(get("/lotteries"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tickets").isArray())
+                .andExpect(jsonPath("$.tickets.length()").value(0));
+    }
+    
+}

--- a/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/UserControllerTest.java
+++ b/posttest/src/test/java/com/kbtg/bootcamp/posttest/controllers/UserControllerTest.java
@@ -1,0 +1,94 @@
+package com.kbtg.bootcamp.posttest.controllers;
+
+import com.kbtg.bootcamp.posttest.configs.SecurityConfig;
+import com.kbtg.bootcamp.posttest.entities.UserTicket;
+import com.kbtg.bootcamp.posttest.exceptions.LotteryNotFoundException;
+import com.kbtg.bootcamp.posttest.exceptions.LotterySoldOutException;
+import com.kbtg.bootcamp.posttest.services.LotteryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Import(SecurityConfig.class)
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LotteryService lotteryService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @DisplayName("When buy lottery with exist ticket id then response correctly with status ok")
+    void whenBuyLotteryWithExistTicketId_thenResponseCorrectlyWithStatusOk() throws Exception {
+        when(this.lotteryService.buyLottery(any(), any())).thenReturn(
+                UserTicket
+                        .builder()
+                        .id(1)
+                        .userId("username")
+                        .ticketId("123456")
+                        .amount(1)
+                        .build()
+        );
+
+        this.mvc.perform(
+            post("/users/username/lotteries/123456")
+                    .with(csrf())
+        )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.id").value("1"));
+    }
+
+    @Test
+    @DisplayName("When buy lottery with not exist ticket id then response with status not found")
+    void whenBuyLotteryWithNotExistTicketId_thenResponseWithStatusNotFound() throws Exception {
+        when(this.lotteryService.buyLottery(any(), eq("987654"))).thenThrow(LotteryNotFoundException.class);
+
+        this.mvc.perform(
+                post("/users/username/lotteries/987654")
+                        .with(csrf())
+        )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("When buy lottery that is already sold out then response with status not found")
+    void whenBuyLotteryThatIsAlreadySoldOut_thenResponseWithStatusNotFound() throws Exception {
+        when(this.lotteryService.buyLottery(any(), eq("123456"))).thenThrow(LotterySoldOutException.class);
+
+        this.mvc.perform(
+                post("/users/username/lotteries/123456")
+                        .with(csrf())
+        )
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
Add buy lottery endpoint and list lotteries for specific user endpoint, also add new entity UserTicket to represent new user_ticket table that stored ticket owned by user.

Update unit test and integration test according to this feature

Add initialize database sql script (data-postgresql.sql) for integration testing